### PR TITLE
Ignore empty delta updates

### DIFF
--- a/Sources/UICollectionView/CollectionViewDataSource.swift
+++ b/Sources/UICollectionView/CollectionViewDataSource.swift
@@ -21,7 +21,7 @@ open class CollectionViewDataSource<DS, VF>: NSObject, UICollectionViewDataSourc
         super.init()
 
         self.subscription = dataSource.updateHandler.subscribe { [weak self] update in
-            guard let `self` = self, !self.ignoreDataSourceUpdates else { return }
+            guard let `self` = self, !update.isEmpty, !self.ignoreDataSourceUpdates else { return }
             viewUpdate(update)
         }
     }

--- a/Sources/UITableView/TableViewDataSource.swift
+++ b/Sources/UITableView/TableViewDataSource.swift
@@ -21,7 +21,7 @@ open class TableViewDataSource<DS, VF>: NSObject, UITableViewDataSource where DS
         super.init()
 
         self.subscription = dataSource.updateHandler.subscribe { [weak self] update in
-            guard let `self` = self, !self.ignoreDataSourceUpdates else { return }
+            guard let `self` = self, !update.isEmpty, !self.ignoreDataSourceUpdates else { return }
             viewUpdate(update)
         }
     }

--- a/Sources/Updates.swift
+++ b/Sources/Updates.swift
@@ -10,6 +10,24 @@ public enum IndexedUpdate {
         deletedRows: [IndexPath]
     )
     case full
+
+    /// Whether the update is considered empty.
+    ///
+    /// - `true` for delta updates with no content
+    /// - `false` in all other cases
+    public var isEmpty: Bool {
+        switch self {
+        case let .delta(insertedSections, updatedSections, deletedSections, insertedRows, updatedRows, deletedRows):
+            return insertedSections.isEmpty &&
+                updatedSections.isEmpty &&
+                deletedSections.isEmpty &&
+                insertedRows.isEmpty &&
+                updatedRows.isEmpty &&
+                deletedRows.isEmpty
+        case .full:
+            return false
+        }
+    }
 }
 
 public class IndexedUpdateHandler {


### PR DESCRIPTION
When computing delta updates, it is possible to end up with an empty update.

Sending an empty update to the view update closures would result in an empty call to `performBatchUpdates` (for `UICollectionView`), or a `beginUpdates`+`endUpdates` pair with no changes inside (for `UITableView`).

Such empty update calls can cause animation glitches if they happen while the view is performing other animated updates, such as scrolling and hiding a `UIRefreshControl` after a pull-to-refresh operation.

This PR adds a check in `TableViewDataSource` and `CollectionViewDataSource`. If the update is empty there is no reason to send it to the view update closure.