### PR TITLE
Remove superfluous updates from BasicDataSource when moving items

### DIFF
--- a/Sources/BasicData/BasicDataSource.swift
+++ b/Sources/BasicData/BasicDataSource.swift
@@ -35,8 +35,10 @@ public class BasicDataSource<Section>: DataSourceType where Section: SectionType
     }
 
     public func moveItem(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        var sections = self.sections
         let item = sections[sourceIndexPath.section].items[sourceIndexPath.item]
         sections[sourceIndexPath.section].items.remove(at: sourceIndexPath.item)
         sections[destinationIndexPath.section].items.insert(item, at: destinationIndexPath.item)
+        self.sections = sections
     }
 }


### PR DESCRIPTION
This PR removes superfluous updates on `BasicDataSource`'s update handler when moving items. The cause of the extra update was in-place mutation of `sections` resulting in an update being sent for both the removal and insertion.