### PR TITLE
Added `CompositeDataSource` type 

### DIFF
--- a/Examples/Podfile.lock
+++ b/Examples/Podfile.lock
@@ -2,9 +2,9 @@ PODS:
   - Dwifft (0.9)
   - Nimble (8.0.4)
   - Quick (2.2.0)
-  - SimpleSource (2.0.1):
+  - SimpleSource (2.0.4):
     - Dwifft (~> 0.9.0)
-  - SimpleSource/Tests (2.0.1):
+  - SimpleSource/Tests (2.0.4):
     - Dwifft (~> 0.9.0)
     - Nimble
     - Quick
@@ -27,12 +27,12 @@ EXTERNAL SOURCES:
     :path: ".."
 
 SPEC CHECKSUMS:
-  Dwifft: 42912068ed2a8146077d1a1404df18625bd086e1
-  Nimble: 18d5360282923225d62b09d781f63abc1a0111fc
-  Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
-  SimpleSource: f1f8ffd13c86e68bb7c263239fc33c241823a509
-  SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
+  Dwifft: 1cf1fa6bcd7986d056de5691a658fe5a37548a2e
+  Nimble: 0e052f9872c5f4f6b470f00731a5ca11d3f5161d
+  Quick: 07e5320ad9dd3c7746527180618f6254fa2128b6
+  SimpleSource: 39b5256f15f1ad47321ee3adfbb216f0952e5785
+  SwiftyJSON: 39722d50e4b0f6b4afbba0767477a8c8129123f5
 
 PODFILE CHECKSUM: 6fbaa06e157be018ca9e7d0fd6fb2a32bc98a73b
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.10.0

--- a/Sources/CompositeData/CompositeDataSource.swift
+++ b/Sources/CompositeData/CompositeDataSource.swift
@@ -16,15 +16,12 @@ public class CompositeDataSource<A: DataSourceType, B: DataSourceType>: DataSour
 
         firstDataSourceSubscription = firstDataSource.updateHandler.subscribe { [weak self] update in
             guard let self = self else { return }
-            print("firstDataSourceSubscription update: \(update)")
             self.updateHandler.send(update: update)
         }
 
         secondDataSourceSubscription = secondDataSource.updateHandler.subscribe { [weak self] update in
             guard let self = self else { return }
-            print("secondDataSourceSubscription update: \(update)")
             let mappedUpdate = update.offsetSections(by: firstDataSource.numberOfSections())
-            print("secondDataSourceSubscription update: \(mappedUpdate)")
             self.updateHandler.send(update: mappedUpdate)
         }
     }

--- a/Sources/CompositeData/CompositeDataSource.swift
+++ b/Sources/CompositeData/CompositeDataSource.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public class CompositeDataSource<A: DataSourceType, B: DataSourceType>: DataSourceType
+{
+    public var updateHandler = IndexedUpdateHandler()
+
+    let firstDataSource: A
+    let secondDataSource: B
+
+    private var firstDataSourceSubscription: IndexedUpdateHandler.Subscription?
+    private var secondDataSourceSubscription: IndexedUpdateHandler.Subscription?
+
+    public init(firstDataSource: A, secondDataSource: B) {
+        self.firstDataSource = firstDataSource
+        self.secondDataSource = secondDataSource
+
+        firstDataSourceSubscription = firstDataSource.updateHandler.subscribe { [weak self] update in
+            guard let self = self else { return }
+            print("firstDataSourceSubscription update: \(update)")
+            self.updateHandler.send(update: update)
+        }
+
+        secondDataSourceSubscription = secondDataSource.updateHandler.subscribe { [weak self] update in
+            guard let self = self else { return }
+            print("secondDataSourceSubscription update: \(update)")
+            let mappedUpdate = update.offsetSections(by: firstDataSource.numberOfSections())
+            print("secondDataSourceSubscription update: \(mappedUpdate)")
+            self.updateHandler.send(update: mappedUpdate)
+        }
+    }
+}
+
+public extension CompositeDataSource
+{
+    enum Item {
+        case A(A.Item)
+        case B(B.Item)
+    }
+}
+
+extension CompositeDataSource.Item: Equatable where A.Item: Equatable, B.Item: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case let (.A(lhsA), .A(rhsA)):
+            return lhsA == rhsA
+        case let (.B(lhsB), .B(rhsB)):
+            return lhsB == rhsB
+        default:
+            return false
+        }
+    }
+}
+
+public extension CompositeDataSource {
+    func numberOfSections() -> Int {
+        firstDataSource.numberOfSections() + secondDataSource.numberOfSections()
+    }
+
+    func numberOfItems(in section: Int) -> Int {
+        if sectionIsInFirstDataSource(section) {
+            return firstDataSource.numberOfItems(in: section)
+        } else {
+            let mappedSection = section - firstDataSource.numberOfSections()
+            return secondDataSource.numberOfItems(in: mappedSection)
+        }
+    }
+
+    func item(at indexPath: IndexPath) -> Item? {
+        if sectionIsInFirstDataSource(indexPath.section) {
+            return firstDataSource.item(at: indexPath).map { Item.A($0) }
+        } else {
+            let mappedIndexPath = IndexPath(
+                item: indexPath.item,
+                section: indexPath.section - firstDataSource.numberOfSections()
+            )
+            return secondDataSource.item(at: mappedIndexPath).map { Item.B($0) }
+        }
+    }
+}
+
+private extension CompositeDataSource {
+    func sectionIsInFirstDataSource(_ section: Int) -> Bool {
+        return section < firstDataSource.numberOfSections()
+    }
+}
+
+private extension IndexedUpdate {
+    func offsetSections(by sectionOffset: Int) -> Self {
+        switch self {
+        case var .delta(
+            insertedSections,
+            updatedSections,
+            deletedSections,
+            insertedRows,
+            updatedRows,
+            deletedRows
+        ):
+            insertedSections = IndexSet(insertedSections.map { $0 + sectionOffset })
+            updatedSections = IndexSet(updatedSections.map { $0 + sectionOffset })
+            deletedSections = IndexSet(deletedSections.map { $0 + sectionOffset })
+            insertedRows = insertedRows.map { IndexPath(item: $0.item, section: $0.section + sectionOffset) }
+            updatedRows = updatedRows.map { IndexPath(item: $0.item, section: $0.section + sectionOffset) }
+            deletedRows = deletedRows.map { IndexPath(item: $0.item, section: $0.section + sectionOffset) }
+
+            return .delta(
+                insertedSections: insertedSections,
+                updatedSections: updatedSections,
+                deletedSections: deletedSections,
+                insertedRows: insertedRows,
+                updatedRows: updatedRows,
+                deletedRows: deletedRows
+            )
+
+        case .full:
+            return self
+        }
+    }
+}

--- a/Sources/Updates.swift
+++ b/Sources/Updates.swift
@@ -60,6 +60,8 @@ public class IndexedUpdateHandler {
     
     private typealias Token = String
     private var observers = [Token : Observer]()
+
+    public init() {}
     
     deinit {
         observers.removeAll()

--- a/Sources/Updates.swift
+++ b/Sources/Updates.swift
@@ -29,6 +29,24 @@ public enum IndexedUpdate: Equatable {
         }
     }
 
+    public static func createDelta(
+        insertedSections: IndexSet = .init(),
+        updatedSections: IndexSet = .init(),
+        deletedSections: IndexSet = .init(),
+        insertedRows: [IndexPath] = [],
+        updatedRows: [IndexPath] = [],
+        deletedRows: [IndexPath] = []
+    ) -> Self {
+        .delta(
+            insertedSections: insertedSections,
+            updatedSections: updatedSections,
+            deletedSections: deletedSections,
+            insertedRows: insertedRows,
+            updatedRows: updatedRows,
+            deletedRows: deletedRows
+        )
+    }
+
     var isLikelyToCrashUIKitViews: Bool {
         switch self {
         case let .delta(insertedSections, updatedSections, deletedSections, insertedRows, updatedRows, deletedRows):
@@ -81,7 +99,7 @@ public class IndexedUpdateHandler {
         send(update: .full)
     }
     
-    func send(update: IndexedUpdate) {
+    public func send(update: IndexedUpdate) {
         observers.values.forEach { $0(update) }
     }
 }

--- a/Tests/CompositeDataSourceTests.swift
+++ b/Tests/CompositeDataSourceTests.swift
@@ -1,0 +1,213 @@
+import Quick
+import Nimble
+import SimpleSource
+
+class CompositeDataSourceTests: QuickSpec {
+
+    override func spec() {
+        describe("A basic `CompositeDataSource`") {
+            typealias SimpleCompositeDataSource = CompositeDataSource<DataSourceA, DataSourceB>
+            typealias DataSourceA = BasicDataSource<BasicIdentifiableSection<String>>
+            typealias DataSourceB = BasicDataSource<BasicIdentifiableSection<Int>>
+
+            let stringSectionA = BasicIdentifiableSection(sectionIdentifier: "stringsA", items: [
+                "Section A - Item 0",
+                "Section A - Item 1",
+                "Section A - Item 2",
+                "Section A - Item 3",
+                "Section A - Item 4",
+                "Section A - Item 5",
+                "Section A - Item 6",
+            ])
+            let stringSectionB = BasicIdentifiableSection(sectionIdentifier: "stringsB", items: [
+                "Section B - Item 0",
+                "Section B - Item 1",
+                "Section B - Item 2",
+            ])
+            let intSectionA = BasicIdentifiableSection(sectionIdentifier: "intsA", items: [
+                1000,
+                1001,
+                1002,
+                1003,
+                1004,
+            ])
+            let intSectionB = BasicIdentifiableSection(sectionIdentifier: "intsB", items: [
+                1100,
+                1101,
+                1102,
+                1103,
+                1104,
+                1105,
+                1106,
+                1107,
+                1108,
+            ])
+            let intSectionC = BasicIdentifiableSection(sectionIdentifier: "intsC", items: [
+                1200,
+                1201,
+            ])
+            let sections = [
+                stringSectionA.items,
+                stringSectionB.items,
+                intSectionA.items,
+                intSectionB.items,
+                intSectionC.items
+            ] as [[Any]]
+
+            let dataSourceA = DataSourceA(sections: [stringSectionA, stringSectionB])
+            let dataSourceB = DataSourceB(sections: [intSectionA, intSectionB, intSectionC])
+            let compositeDataSource = SimpleCompositeDataSource(
+                firstDataSource: dataSourceA,
+                secondDataSource: dataSourceB
+            )
+
+            let startingItemLookup = { (indexPath: IndexPath) -> SimpleCompositeDataSource.Item? in
+                switch indexPath.section {
+                case 0: return .A(stringSectionA.items[indexPath.row])
+                case 1: return .A(stringSectionB.items[indexPath.row])
+                case 2: return .B(intSectionA.items[indexPath.row])
+                case 3: return .B(intSectionB.items[indexPath.row])
+                case 4: return .B(intSectionC.items[indexPath.row])
+                default: return nil
+                }
+            }
+            let currentItemLookup = { (indexPath: IndexPath) -> SimpleCompositeDataSource.Item? in
+                compositeDataSource.item(at: indexPath)
+            }
+
+            describe("initial state") {
+                it("should have expected number of sections") {
+                    expect(compositeDataSource.numberOfSections()).to(equal(sections.count))
+                }
+
+                it("should have expected number of items per section") {
+                    for section in 0 ..< compositeDataSource.numberOfSections() {
+                        expect(compositeDataSource.numberOfItems(in: section)).to(equal(sections[section].count))
+                    }
+                }
+
+                it("should have the items in the correct order") {
+                    for sectionIndex in 0 ..< compositeDataSource.numberOfSections() {
+                        for itemIndex in 0 ..< compositeDataSource.numberOfItems(in: sectionIndex) {
+                            let indexPath = IndexPath(item: itemIndex, section: sectionIndex)
+                            expect(startingItemLookup(indexPath)).to(equal(currentItemLookup(indexPath)))
+                        }
+                    }
+                }
+            }
+
+            describe("state changes") {
+                var receivedChanges = [IndexedUpdate]()
+                var changesSubscription: IndexedUpdateHandler.Subscription?
+
+                beforeEach {
+                    receivedChanges.removeAll()
+                    changesSubscription = compositeDataSource.updateHandler.subscribe { receivedChanges += [$0] }
+                    expect(changesSubscription).toNot(be(nil)) // Did this to shut up warning about unread variable
+                }
+
+                context("dataSourceA gets a new second section") {
+                    let newSecondSection = BasicIdentifiableSection(sectionIdentifier: "stringsB", items: [
+                        "This is item 1.0",
+                        "This is item 1.1",
+                    ])
+
+                    beforeEach { dataSourceA.sections = [stringSectionA, newSecondSection] }
+                    afterEach { dataSourceA.sections = [stringSectionA, stringSectionB] }
+
+                    it("should signal the correct delta") {
+                        expect(receivedChanges.count).to(be(1))
+                        let expectedUpdate = IndexedUpdate.delta(
+                            insertedSections: .init(),
+                            updatedSections: .init(),
+                            deletedSections: .init(),
+                            insertedRows: [
+                                .init(item: 0, section: 1),
+                                .init(item: 1, section: 1)
+                            ],
+                            updatedRows: [],
+                            deletedRows: [
+                                .init(item: 2, section: 1),
+                                .init(item: 1, section: 1),
+                                .init(item: 0, section: 1),
+                            ]
+                        )
+                        expect(receivedChanges.first).to(equal(expectedUpdate))
+                    }
+
+                    it("should contain the right data where expected") {
+                        for sectionIndex in 0 ..< compositeDataSource.numberOfSections() {
+                            for itemIndex in 0 ..< compositeDataSource.numberOfItems(in: sectionIndex) {
+                                let indexPath = IndexPath(item: itemIndex, section: sectionIndex)
+                                switch sectionIndex {
+                                case 1:
+                                    expect(currentItemLookup(indexPath)).to(equal(.A(newSecondSection.items[itemIndex])))
+                                default:
+                                    expect(currentItemLookup(indexPath)).to(equal(startingItemLookup(indexPath)))
+                                }
+                            }
+                        }
+                    }
+                }
+
+                context("dataSourceB gets a new second section") {
+                    let newSecondSection = BasicIdentifiableSection(sectionIdentifier: "intsB", items: [
+                        2300,
+                        2301,
+                        2302,
+                        2303,
+                        2304,
+                    ])
+
+                    beforeEach { dataSourceB.sections = [intSectionA, newSecondSection, intSectionC] }
+                    afterEach { dataSourceB.sections = [intSectionA, intSectionB, intSectionC] }
+
+                    it("should signal the correct delta") {
+                        expect(receivedChanges.count).to(be(1))
+                        let expectedUpdate = IndexedUpdate.delta(
+                            insertedSections: .init(),
+                            updatedSections: .init(),
+                            deletedSections: .init(),
+                            insertedRows: [
+                                .init(item: 0, section: 3),
+                                .init(item: 1, section: 3),
+                                .init(item: 2, section: 3),
+                                .init(item: 3, section: 3),
+                                .init(item: 4, section: 3),
+                            ],
+                            updatedRows: [],
+                            deletedRows: [
+                                .init(item: 8, section: 3),
+                                .init(item: 7, section: 3),
+                                .init(item: 6, section: 3),
+                                .init(item: 5, section: 3),
+                                .init(item: 4, section: 3),
+                                .init(item: 3, section: 3),
+                                .init(item: 2, section: 3),
+                                .init(item: 1, section: 3),
+                                .init(item: 0, section: 3),
+                            ]
+                        )
+                        expect(receivedChanges.first).to(equal(expectedUpdate))
+                    }
+
+                    it("should contain the right data where expected") {
+                        for sectionIndex in 0 ..< compositeDataSource.numberOfSections() {
+                            for itemIndex in 0 ..< compositeDataSource.numberOfItems(in: sectionIndex) {
+                                let indexPath = IndexPath(item: itemIndex, section: sectionIndex)
+                                switch sectionIndex {
+                                case 3:
+                                    expect(currentItemLookup(indexPath)).to(equal(.B(newSecondSection.items[itemIndex])))
+                                default:
+                                    expect(currentItemLookup(indexPath)).to(equal(startingItemLookup(indexPath)))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
Depends on #10 

It works by generically wrapping two `DataSourceType`s while conforming to the same protocol itself.
It subscribes to updates from both data sources, mapping the changes into it's own section space and publishing those updates to subscribers of the composite.
The tests show this mapping is working correctly.