### PR TITLE
MOBILE-1950: Migrate all tests to Quick 7 (Nimble 12)

### DIFF
--- a/Examples/Podfile.lock
+++ b/Examples/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Dwifft (0.9)
-  - Nimble (10.0.0)
-  - Quick (5.0.1)
+  - Nimble (12.3.0)
+  - Quick (7.3.0)
   - SimpleSource (2.0.5):
     - Dwifft (~> 0.9.0)
   - SimpleSource/Tests (2.0.5):
     - Dwifft (~> 0.9.0)
-    - Nimble (~> 10.0)
-    - Quick (~> 5.0)
+    - Nimble (~> 12.0)
+    - Quick (~> 7.0)
   - SwiftyJSON (5.0.1)
 
 DEPENDENCIES:
@@ -28,9 +28,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Dwifft: 42912068ed2a8146077d1a1404df18625bd086e1
-  Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
-  Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  SimpleSource: 319cae1ee1f41165a9320577b11aad223972f525
+  Nimble: f8a8219d16f176429b951e8f7e72df5c23ceddc0
+  Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
+  SimpleSource: d2aa14f3f8c509cfdd3ee6b30838118bb6e6a4c6
   SwiftyJSON: 2f33a42c6fbc52764d96f13368585094bfd8aa5e
 
 PODFILE CHECKSUM: a5deddba5204624da3222bdb26450e64fabfabc5

--- a/SimpleSource.podspec
+++ b/SimpleSource.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
   s.test_spec 'Tests' do |test_spec|
     test_spec.resource = 'Tests/Model/*.xcdatamodeld'
     test_spec.source_files = 'Tests/**/*.swift'
-    test_spec.dependency 'Nimble', '~> 10.0'
-    test_spec.dependency 'Quick', '~> 5.0'
+    test_spec.dependency 'Nimble', '~> 12.0'
+    test_spec.dependency 'Quick', '~> 7.0'
   end
 end
 

--- a/Tests/BasicDataSourceTests.swift
+++ b/Tests/BasicDataSourceTests.swift
@@ -4,7 +4,7 @@ import SimpleSource
 
 class BasicDataSourceTests: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
         describe("A BasicDataSource") {
 
             typealias Section = BasicSection<String>

--- a/Tests/CoreDataSourceTests.swift
+++ b/Tests/CoreDataSourceTests.swift
@@ -7,36 +7,36 @@ private let StoreFilename = "SimpleSource-UnitTest-Store"
 
 class CoreDataSourceTests: QuickSpec {
     
-    lazy var model: NSManagedObjectModel = {
-        let modelURL = Bundle(for: type(of: self)).url(forResource: "TestModel", withExtension: "momd")!
+    static var model: NSManagedObjectModel = {
+        let modelURL = Bundle(for: CoreDataSourceTests.self).url(forResource: "TestModel", withExtension: "momd")!
         return NSManagedObjectModel(contentsOf: modelURL)!
     }()
     
-    lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator = {
+    static var persistentStoreCoordinator: NSPersistentStoreCoordinator = {
         let fileManager = FileManager.default
         let directoryURL = try! fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         let url = directoryURL.appendingPathComponent("\(StoreFilename).sqlite")
         try? fileManager.removeItem(at: url)
-        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: self.model)
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
         try? _ = coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: url, options: nil)
         return coordinator
     }()
     
-    lazy var context: NSManagedObjectContext = {
+    static var context: NSManagedObjectContext = {
         let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        managedObjectContext.persistentStoreCoordinator = self.persistentStoreCoordinator
+        managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
         return managedObjectContext
     }()
     
-    lazy var fetchController: NSFetchedResultsController = { () -> NSFetchedResultsController<TestEntity> in
+    static var fetchController: NSFetchedResultsController = { () -> NSFetchedResultsController<TestEntity> in
         let request: NSFetchRequest<TestEntity> = TestEntity.fetchRequest()
         request.sortDescriptors = [NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: true)]
-        let controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: self.context, sectionNameKeyPath: #keyPath(TestEntity.section), cacheName: nil)
+        let controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: context, sectionNameKeyPath: #keyPath(TestEntity.section), cacheName: nil)
         try? controller.performFetch()
         return controller
     }()
     
-    override func spec() {
+    override class func spec() {
         describe("A CoreDataSource") {
             
             let dataSource = CoreDataSource(fetchedResultsController: fetchController)
@@ -130,8 +130,8 @@ class CoreDataSourceTests: QuickSpec {
         }
     }
     
-    private func createEntity(name: String, section: Int16) -> TestEntity {
-        let entity = NSEntityDescription.insertNewObject(forEntityName: "TestEntity", into: self.context) as! TestEntity
+    private static func createEntity(name: String, section: Int16) -> TestEntity {
+        let entity = NSEntityDescription.insertNewObject(forEntityName: "TestEntity", into: context) as! TestEntity
         entity.name = name
         entity.section = section
         return entity

--- a/Tests/UIKitViewUpdateTests.swift
+++ b/Tests/UIKitViewUpdateTests.swift
@@ -23,7 +23,7 @@ class UIKitViewUpdateTests: QuickSpec {
         var value: Bool
     }
 
-    override func spec() {
+    override class func spec() {
         let vcTypes: [DataSourceUpdateable.Type] = [TableViewController.self, CollectionViewController.self]
         for type in vcTypes {
 


### PR DESCRIPTION
## Description

The test suite was based on pretty old version of Quick so it would be good to migrate it to the latest version.